### PR TITLE
Allow LPAD parsing & better scope transformed program

### DIFF
--- a/examples/calls.pl
+++ b/examples/calls.pl
@@ -1,8 +1,8 @@
 :- style_check(-singleton).
 :- use_module(sampler).
 
-0.1 :: calls(X) <--- [person(X)].
-0.2 :: calls(mary) <--- [].
+0.1::calls(X) <--- [person(X)].
+0.2::calls(mary) <--- [].
 
 person(mary).
 person(george).

--- a/examples/flu.pl
+++ b/examples/flu.pl
@@ -1,10 +1,10 @@
 :- style_check(-singleton).
 :- use_module(sampler).
 
-0.3 :: pandemic <--- [flu(X), cold].
-0.6 :: epidemic <--- [flu(X), cold].
+0.6::epidemic <--- [flu(X), cold].
+0.3::pandemic <--- [flu(X), cold].
 
-0.7 :: cold <--- [].
+0.7::cold <--- [].
 
 flu(robert).
 flu(david).

--- a/examples/lpad.pl
+++ b/examples/lpad.pl
@@ -1,7 +1,11 @@
+:- style_check(-singleton).
+:- use_module(sampler).
 
-0.6 :: epidemic ; 0.3 :: pandemic <--- [flu(X), cold]
+0.5::chilly; 0.5::freezing <--- [cold].
 
-0.7 :: cold.
+0.6::epidemic; 0.2::pandemic <--- [flu(X), cold].
+
+0.7::cold <--- [].
 
 flu(robert).
 flu(david).

--- a/montecarlo.pl
+++ b/montecarlo.pl
@@ -2,14 +2,14 @@
 
 :- use_module(sampler).
 
-montecarlo(Program, Query, Probability) :-
-	montecarlo(Program, Query, 0.02, Probability).
-montecarlo(Program, Query, Threshold, Probability) :-
-	montecarlo(Program, Query, Threshold, 500, Probability).
-montecarlo(Program, Query, Threshold, BatchSize, Probability) :-
-	sampler:load_program(Program, TransformedRules),
+montecarlo(File, Query, Probability) :-
+	montecarlo(File, Query, 0.02, Probability).
+montecarlo(File, Query, Threshold, Probability) :-
+	montecarlo(File, Query, Threshold, 500, Probability).
+montecarlo(File, Query, Threshold, BatchSize, Probability) :-
+	sampler:load_program(File),
 	take_samples(Query, Threshold, BatchSize, Probability),
-	sampler:unload_program(Program, TransformedRules).
+	sampler:unload_program.
 
 take_samples(Query, Threshold, BatchSize, Probability) :-
 	take_samples(Query, Threshold, BatchSize, 0, 0, Probability).

--- a/sampler.pl
+++ b/sampler.pl
@@ -1,55 +1,104 @@
 :- module(sampler, [
-	load_program/2,
-	unload_program/2,
+	load_program/1,
+	unload_program/0,
 	sample_goal/1,
-	op(1200, xfx, <---),
-	op(1000, xfy, ::)
+	op(1120, xfx, <---),
+	op(1080, xfy, ::)
 ]).
 
 :- dynamic((<---)/2).
 :- dynamic((::)/2).
 
 /*
-	Load the object program under the given [Program] source and transform its content for future sampling.
+	Load the PLP under the given [File] source and transform it's content for future sampling.
 */
-load_program(Program, TransformedRules) :-
-	consult(Program),
-	findall(Weight :: Head <--- Body, sampler: (Weight :: Head <--- Body), Clauses),
-	maplist(rewrite_pl_body, Clauses, TransformedRules).
+load_program(File) :-
+	transformed:consult(File), % using `transformed` as a namespace to scope the transformed program
+	findall(Head <--- Body, transformed:(Head <--- Body), Clauses),
+	maplist(resolve_disjunct_heads, Clauses, ClausesPerDisjunction), % returns nested list
+	maplist(get_disjunction_weights, ClausesPerDisjunction, WeightsPerDisjunction),
+	assert_disjunctions(ClausesPerDisjunction, WeightsPerDisjunction).
 
 /*
-	Given a single PLP clause, transform it into an equivalent standard prolog clause according to the transformation rules detailed in Riguzzi 2013, p. 7.
+	Parse disjunctions in a clause's head by transforming it into a list of clauses instead,
+	with one element of the disjunction as each new clause's head:
+	0.5::reallycold; 0.5::freezing <--- [cold]
+	↓
+	[0.5::reallycold <--- [cold], 0.5::freezing <--- [cold]]
 */
-rewrite_pl_body(Weight :: Head <--- [Term | Rest], TransformedRule) :-
-	ListBody = [Term | Rest],
-	maplist(collect_free_variables, ListBody, Variables_),
-	exclude(is_empty, Variables_, Variables),
-	list_to_conjunction(ListBody, Conjunction),
-	TransformedRule = (Head :- (Conjunction, sample_head([Weight, 1 - Weight], 1, Variables, NH), NH = 0)),
-	sampler:assert(TransformedRule).
+resolve_disjunct_heads((Head; RestHeads <--- Body), [Head <--- Body | Rest]) :-
+	resolve_disjunct_heads(RestHeads <--- Body, Rest),
+	!.
+resolve_disjunct_heads(LastHead <--- Body, [LastHead <--- Body | []]).
 
-rewrite_pl_body(Weight :: Head <--- [], TransformedRule) :-
-	TransformedRule = (Head :- (sample_head([Weight, 1 - Weight], 1, [], NH), NH = 0)),
-	sampler:assert(TransformedRule).
+/*
+	Write the weights of all clauses inside a disjunction into a list,
+	adding a null weight when they don't add up to 1.0.
+*/
+get_disjunction_weights(Disjunction, Weights) :-
+	get_disjunction_weights(Disjunction, Weights, 0).
+get_disjunction_weights([Weight::_Head <--- _Body | RestClauses], [Weight | RestWeights], TotalWeight) :-
+	NewTotalWeight is TotalWeight + Weight,
+	get_disjunction_weights(RestClauses, RestWeights, NewTotalWeight),
+	!.
+get_disjunction_weights([], NullWeightList, TotalWeight) :- % conditionally add null weight
+	(TotalWeight < 1.0 ->
+		NullWeightList = [1.0 - TotalWeight | []]
+	;
+		NullWeightList = []
+	).
 
-is_empty([]).
+% Loop disjunctions, keeping track of their indices.
+assert_disjunctions(ClausesPerDisjunction, WeightsPerDisjunction) :-
+	assert_disjunctions(ClausesPerDisjunction, WeightsPerDisjunction, 0).
+assert_disjunctions([Disjunction | RestDisjunctions], [Weights | RestWeights], CurrDisjunctionIndex) :-
+	assert_disjunction(Disjunction, Weights, CurrDisjunctionIndex),
+	NewDisjunctionIndex is CurrDisjunctionIndex + 1,
+	assert_disjunctions(RestDisjunctions, RestWeights, NewDisjunctionIndex),
+	!.
+assert_disjunctions([], [], _DisjunctionIndex).
+
+% Loop clauses inside disjunction, keeping track of the clause indices
+% (matching the original head indices of the combined disjunctive clause).
+assert_disjunction(Disjunctions, Weights, DisjunctionIndex) :-
+	assert_disjunction(Disjunctions, Weights, DisjunctionIndex, 0).
+assert_disjunction([Clause | RestClauses], Weights, DisjunctionIndex, CurrHeadIndex) :-
+	assert_clause(Clause, Weights, DisjunctionIndex, CurrHeadIndex),
+	NewHeadIndex is CurrHeadIndex + 1,
+	assert_disjunction(RestClauses, Weights, DisjunctionIndex, NewHeadIndex),
+	!.
+assert_disjunction([], _Weights, _DisjunctionIndex, _CurrHeadIndex).
+
+/*
+	Given a single PLP clause, transform it into an equivalent standard Prolog clause
+	according to the transformation rules detailed in Riguzzi 2013, p. 7.
+*/
+assert_clause(_Weight::Head <--- [], Weights, DisjunctionIndex, HeadIndex) :-
+	Transformed = (Head :- (sampler:sample_head(Weights, DisjunctionIndex, [], NH), NH = HeadIndex)),
+	transformed:assertz(Transformed).
+assert_clause(_Weight::Head <--- [BodyHead | BodyRest], Weights, DisjunctionIndex, HeadIndex) :-
+	Body = [BodyHead | BodyRest],
+	maplist(term_variables, Body, ConjunctionsVariables),
+	flatten(ConjunctionsVariables, Variables),
+	list_to_conjunction(Body, BodyConjunction),
+	Transformed = (Head :- (BodyConjunction, sampler:sample_head(Weights, DisjunctionIndex, Variables, NH), NH = HeadIndex)),
+	transformed:assertz(Transformed).
+
+/*
+	Transform a list of terms extracted from an object program's clause
+	into a standard prolog conjunction.
+*/
+list_to_conjunction([Term], Term) :-
+	!.
+list_to_conjunction([Term | Rest], ','(Term, Conjunction)) :-
+	list_to_conjunction(Rest, Conjunction).
 
 /*
 	Cleanup environment state (usually after running a sampling process to completion).
  */
-unload_program(Program, TransformedRules) :-
-	unload_file(Program), maplist(retract_clause, TransformedRules).
-
-retract_clause(Head :- _) :- retractall(Head).
-
-/*
-	Transform a list of terms extracted from an object program's clause into a standard prolog conjunction.
-*/
-list_to_conjunction([Term], Term) :- !.
-list_to_conjunction([Term | Rest], ','(Term, Conjunction)) :-
-	list_to_conjunction(Rest, Conjunction).
-
-collect_free_variables(Body, FreeVariables) :- term_variables(Body, FreeVariables).
+unload_program :-
+	findall(Predicate, current_predicate(transformed:Predicate), Predicates),
+	maplist(transformed:abolish, Predicates).
 
 /*
 	Generate a sample for a head, given its respective weights.
@@ -65,7 +114,7 @@ sample(Weights, HeadId) :-
 	random(Prob),
 	sample(Weights, 0, 0, Prob, HeadId).
 
-sample([HeadProb|Tail], Index, Prev, Prob, HeadId) :-
+sample([HeadProb | Tail], Index, Prev, Prob, HeadId) :-
 	Succ is Index + 1,
 	Next is Prev + HeadProb,
 	(Prob =< Next ->
@@ -74,15 +123,14 @@ sample([HeadProb|Tail], Index, Prev, Prob, HeadId) :-
 		sample(Tail, Succ, Next, Prob, HeadId)
 	).
 
-
 /*
-	Assuming a suitable object program has already been prepared via [transform_object_program],
+	Assuming a suitable object program has already been transformed via [load_program],
 	take a sample of the given [Goal].
 */
 sample_goal(Goal) :-
 	abolish_all_tables,
 	clear_recorded_pl_heads,
-	call(Goal).
+	transformed:call(Goal).
 
 /*
 	Erase all previously recorded sample entries from the database.


### PR DESCRIPTION
Der diff ist net so nice weil sich einiges am sampler geändert hat. Hoffentlich grundlegend nachvollziehbar.

Hab jetzt auch im sampler diese Warnung, aber keine Ahnung ob die überhaupt valid ist oder ob die Prolog vscode extension da halt nicht gut ist... 🤷 Konnte ich grad net fixen.

![grafik](https://github.com/lukasrieger/plp-project/assets/21311428/502aaf2e-bcd7-4cdb-bef6-d7494a74ad41)
